### PR TITLE
chore(setup): improve README follow-up and clean AWS scripts

### DIFF
--- a/.docker/docker-compose.override.yml
+++ b/.docker/docker-compose.override.yml
@@ -9,16 +9,16 @@ services:
       - ../tsconfig.build.json:/usr/src/app/tsconfig.build.json
     command: sh -c "npm run bootstrap-db && npm run seed && npm run start:dev"
     environment:
-      - NODE_ENV=development
+      - NODE_ENV
       - DYNAMO_ENDPOINT=http://local-dynamodb:8000
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
-      - AWS_REGION=us-east-2
-      - AWS_SES_FROM_EMAIL=user@example.com
-      - JWT_SECRET=your_jwt_secret
-      - APP_URL=http://localhost:3000
-      - GLOBAL_PREFIX=api/v1
+      - AWS_REGION
+      - AWS_SES_FROM_EMAIL
+      - JWT_SECRET
+      - APP_URL
+      - GLOBAL_PREFIX
   dynamodb-admin:
     image: aaronshaf/dynamodb-admin
     container_name: dynamodb-admin

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -5,6 +5,3 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
-
-load-aws-creds.ps1
-load-aws-creds.sh

--- a/infra/package.json
+++ b/infra/package.json
@@ -8,7 +8,11 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "bootstrap": "cdk bootstrap",
+    "deploy": "cdk deploy --all",
+    "bootstrap:vault": "aws-vault exec compass-event-dev -- cdk bootstrap",
+    "deploy:all:vault": "aws-vault exec compass-event-dev -- npx cdk deploy --all"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "dev:restart": "npm run dev:down && npm run dev:up",
     "dev:restart:vault": "npm run dev:down && npm run dev:up:vault",
     "dev:restart:light": "docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml restart",
+    "dev:restart:light:vault": "aws-vault exec compass-event-dev -- docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml restart",
     "dev:up:no-build": "docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml up -d",
     "dev:up:no-build:vault": "aws-vault exec compass-event-dev -- docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml up -d",
     "dev:start": "docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml start",
     "dev:start:vault": "aws-vault exec compass-event-dev -- docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml start",
     "dev:start:logs": "docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml start && docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml logs -f",
+    "dev:start:logs:vault": "aws-vault exec compass-event-dev -- docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml start && docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml logs -f",
     "dev:reload": "docker-compose -f .docker/docker-compose.yml -f .docker/docker-compose.override.yml restart"
   },
   "dependencies": {

--- a/scripts/load-aws-creds.ps1.example
+++ b/scripts/load-aws-creds.ps1.example
@@ -1,7 +1,0 @@
-# Set AWS temporary credentials as environment variables in PowerShell
-
-$env:AWS_ACCESS_KEY_ID = "ASIAYOURACCESSKEYID"
-$env:AWS_SECRET_ACCESS_KEY = "yourSecretAccessKeyHere"
-$env:AWS_SESSION_TOKEN = "yourSessionTokenHere"
-
-Write-Host "AWS temporary credentials loaded successfully."

--- a/scripts/load-aws-creds.sh.example
+++ b/scripts/load-aws-creds.sh.example
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Export AWS temporary credentials as environment variables in bash
-
-export AWS_ACCESS_KEY_ID="ASIAYOURACCESSKEYID"
-export AWS_SECRET_ACCESS_KEY="yourSecretAccessKeyHere"
-export AWS_SESSION_TOKEN="yourSessionTokenHere"
-
-echo "AWS temporary credentials loaded successfully."


### PR DESCRIPTION
## Summary
This PR improves the project setup process so that other developers can follow the README more easily.  
It removes hardcoded AWS environment variables from Docker and adds convenient package scripts for both infrastructure (`cdk`) and local development (`docker-compose` with aws-vault).  
It also removes outdated scripts for loading AWS credentials and merges the latest `develop` branch.

## Why
- Facilitate onboarding for new developers
- Avoid hardcoding sensitive environment variables
- Provide standardized scripts for deploying and running the project
- Clean up obsolete credential loading scripts to reduce confusion

## How
- **Added/Updated scripts in `package.json`:**  
  - Infra: `"bootstrap"`, `"deploy"`, `"bootstrap:vault"`, `"deploy:all:vault"`  
  - Root: `"dev:restart:light:vault"`, `"dev:start:logs:vault"`  
- **Removed** `load-aws-creds.ps1.example` and `load-aws-creds.sh.example`
- **Merged** latest `develop` into `chore/setup-fixes` to stay up-to-date.  

## Testing
- Verified that new package scripts run correctly
- Docker containers start/restart/log commands work with `aws-vault`
- README instructions now match the updated scripts and environment setup

## Checklist
- [x] Added new scripts for infrastructure and local development
- [x] Removed obsolete credential loading scripts
- [x] Ensured README instructions align with current setup
- [x] Merged latest `develop` without conflicts